### PR TITLE
Corrige le build : restaure loadContent dans le plugin docs-metadata

### DIFF
--- a/web/plugins/docs-metadata/index.js
+++ b/web/plugins/docs-metadata/index.js
@@ -165,13 +165,15 @@ module.exports = function pluginDocsMetadata(context, options) {
     /**
      * Chargement des métadonnées à partir des fichiers Markdown
      */
-    async contentLoaded({ content, actions }) {
-      actions.setGlobalData({ routeBasePath });
+    async loadContent() {
+      return getAllDocsMetadata({ docsDir });
     },
     /**
-     * Génère le fichier docsMetadata.json dans static/ pour qu'il soit déployé
+     * Expose le segment de route aux composants et génère le fichier
+     * docsMetadata.json dans static/ pour qu'il soit déployé
      */
-    async contentLoaded({ content }) {
+    async contentLoaded({ content, actions }) {
+      actions.setGlobalData({ routeBasePath });
       fs.writeFileSync(
         getStaticMetadataPath(),
         JSON.stringify(content, null, 2)


### PR DESCRIPTION
Le hook loadContent avait été remplacé par un second contentLoaded, qui écrasait le premier. Sans loadContent, content valait undefined et JSON.stringify(undefined) faisait échouer fs.writeFileSync.

Les deux hooks sont fusionnés en un seul contentLoaded qui expose routeBasePath et écrit docsMetadata.json.